### PR TITLE
コーディング規則に１行の文字数制限を追加

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -11,6 +11,7 @@
 2. branchを切る
 3. コードを書く
     - [C# のコーディング規則](https://docs.microsoft.com/ja-jp/dotnet/csharp/fundamentals/coding-style/coding-conventions#naming-conventions)になるべく従うこと
+    - 厳密に守る必要はありませんが、できるだけ一行を100文字以下に収める
     - 用語や英単語に関しては[仕様書](specification/)で使われているものに統一する
 4. commitする
 5. pushする

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -11,7 +11,7 @@
 2. branchを切る
 3. コードを書く
     - [C# のコーディング規則](https://docs.microsoft.com/ja-jp/dotnet/csharp/fundamentals/coding-style/coding-conventions#naming-conventions)になるべく従うこと
-    - 厳密に守る必要はありませんが、できるだけ一行を100文字以下に収める
+    - 厳密に守る必要はないが、できるだけ一行を100文字以下に収める
     - 用語や英単語に関しては[仕様書](specification/)で使われているものに統一する
 4. commitする
 5. pushする


### PR DESCRIPTION
一行の文字数が長くなりすぎると見切れて読みづらくなる。また、コードが冗長だったり、カプセル化ができていなかったり、ネストが深すぎて可読性が下がってるなどの問題が絡んでることも多いので、コーディング規則で一行の文字数の上限が指定されていることがよくある（たとえば、[GoogleのC#のコーディング規則](https://gist.github.com/hideyukisaito/d298075c63b97f56825b0d413d8e4dc5) でも100文字制限がある）。
我々のコードも少し読みづらくなってきているので規約に追加してみました